### PR TITLE
Cambios PluginQGIS:

### DIFF
--- a/qgisplugin/HydroSEDPlugin.py
+++ b/qgisplugin/HydroSEDPlugin.py
@@ -221,7 +221,7 @@ class HydroSEDPlugin:
             #    removed on close (see self.onClosePlugin method)
             if self.dockwidget == None:
                 # Create the dockwidget (after translation) and keep reference
-                self.dockwidget = HydroSEDPluginDockWidget()
+                self.dockwidget = HydroSEDPluginDockWidget(iface = self.iface)
 
             # connect to provide cleanup on closing of dockwidget
             self.dockwidget.closingPlugin.connect(self.onClosePlugin)

--- a/qgisplugin/HydroSEDPlugin_dockwidget.py
+++ b/qgisplugin/HydroSEDPlugin_dockwidget.py
@@ -29,6 +29,8 @@ from PyQt4.QtCore import pyqtSignal
 from qgis.gui import QgsMessageBar
 from PyQt4.QtGui import QFileDialog
 
+import os.path
+
 from wmf import wmf
 
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
@@ -39,7 +41,7 @@ class HydroSEDPluginDockWidget(QtGui.QDockWidget, FORM_CLASS):
 
     closingPlugin = pyqtSignal()
 
-    def __init__(self, parent=None):
+    def __init__(self, iface = None, parent=None):
 
         """Constructor."""
         super(HydroSEDPluginDockWidget, self).__init__(parent)
@@ -51,6 +53,9 @@ class HydroSEDPluginDockWidget(QtGui.QDockWidget, FORM_CLASS):
         self.setupUi(self)
         self.setupUIInputsOutputs ()
         self.setupUIButtonEvents ()
+
+        if not (iface is None):
+            self.iface = iface
 
     def closeEvent(self, event):
 
@@ -83,6 +88,14 @@ class HydroSEDPluginDockWidget(QtGui.QDockWidget, FORM_CLASS):
 
     def setupUIInputsOutputs (self):
 
+        def setupLineEditButtonOpenShapeFileDialog (lineEditHolder, fileDialogHolder):
+
+            lineEditHolder.setText (fileDialogHolder.getOpenFileName (QtGui.QDialog (), "", "*", "Shapefiles (*.shp);;"))
+
+            if ((os.path.exists (lineEditHolder.text ().strip ())) and (not (self.iface is None))):
+
+                self.iface.addVectorLayer (lineEditHolder.text ().strip (), os.path.basename (lineEditHolder.text ()).strip (), "ogr")
+
         def setupLineEditButtonOpenFileDialog (lineEditHolder, fileDialogHolder):
 
             lineEditHolder.setText (fileDialogHolder.getOpenFileName ())
@@ -93,11 +106,13 @@ class HydroSEDPluginDockWidget(QtGui.QDockWidget, FORM_CLASS):
 
         def clickEventSelectorMapaDEM ():
 
-            setupLineEditButtonOpenFileDialog (self.lineEditMapaDEM, QFileDialog)
+#            setupLineEditButtonOpenFileDialog (self.lineEditMapaDEM, QFileDialog)
+            setupLineEditButtonOpenShapeFileDialog (self.lineEditMapaDEM, QFileDialog)
 
         def clickEventSelectorMapaDIR ():
 
-            setupLineEditButtonOpenFileDialog (self.lineEditMapaDIR, QFileDialog)
+#            setupLineEditButtonOpenFileDialog (self.lineEditMapaDIR, QFileDialog)
+            setupLineEditButtonOpenShapeFileDialog (self.lineEditMapaDIR, QFileDialog)
 
         def clickEventSelectorBinarioNC ():
 
@@ -109,7 +124,8 @@ class HydroSEDPluginDockWidget(QtGui.QDockWidget, FORM_CLASS):
 
         def clickEventSelectorInputCorrienteShapefileTrazadorCuencas ():
 
-            setupLineEditButtonOpenFileDialog (self.lineEditInputCorrienteShapefileTrazadorCuencas, QFileDialog)
+#            setupLineEditButtonOpenFileDialog (self.lineEditInputCorrienteShapefileTrazadorCuencas, QFileDialog)
+            setupLineEditButtonOpenShapeFileDialog (self.lineEditInputCorrienteShapefileTrazadorCuencas, QFileDialog)
 
         def clickEventSelectorOutputCuencaShapefileTrazadorCuencas ():
 

--- a/qgisplugin/HydroSEDPlugin_dockwidget_base.ui
+++ b/qgisplugin/HydroSEDPlugin_dockwidget_base.ui
@@ -27,7 +27,7 @@
     <item>
      <widget class="QTabWidget" name="tabPanelDockOpciones">
       <property name="currentIndex">
-       <number>3</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="tabConfiguracion">
        <attribute name="title">
@@ -562,50 +562,11 @@
        <attribute name="title">
         <string>Hidrología</string>
        </attribute>
-       <widget class="QPushButton" name="pushButton">
-        <property name="geometry">
-         <rect>
-          <x>60</x>
-          <y>50</y>
-          <width>99</width>
-          <height>27</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>PushButton</string>
-        </property>
-       </widget>
       </widget>
       <widget class="QWidget" name="tab_2">
        <attribute name="title">
         <string>Geomorfología</string>
        </attribute>
-       <widget class="QPushButton" name="pushButton_2">
-        <property name="geometry">
-         <rect>
-          <x>110</x>
-          <y>50</y>
-          <width>99</width>
-          <height>27</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>PushButton</string>
-        </property>
-       </widget>
-       <widget class="QPushButton" name="pushButton_3">
-        <property name="geometry">
-         <rect>
-          <x>130</x>
-          <y>100</y>
-          <width>99</width>
-          <height>27</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>PushButton</string>
-        </property>
-       </widget>
       </widget>
      </widget>
     </item>


### PR DESCRIPTION
   HydroSEDPlugin_dockwidget_base.ui (Elimine botones innecesarios en tabs)
   HydroSEDPlugin.py
       Se cambia constructor referenciado de HydroSEDPlugin_dockwidget para enviar el iface y poder cargar las capas desde alli
   HydroSEDPlugin_dockwidget.py
      Constructor (Para pasar el iface de QGIS) y poder agregar la capa desde la vista interna
      setupLineEditButtonOpenShapeFileDialog (Metodo para el selector de archivos pero cargando la capa y restringiendo solo a archivos *.shp)
      Se modificaron los selectores de DEM/DIR/Corriente (Para Cuenca) para que usen este nuevo metodo y carguen la capa automaticamente